### PR TITLE
Fix SecurityContext vs PodSecurityContext mismatch

### DIFF
--- a/kubernetes/migrate.yml
+++ b/kubernetes/migrate.yml
@@ -14,13 +14,13 @@ metadata:
       RAILS_ENV
 spec:
   restartPolicy: Never
-  securityContext:
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
   containers:
   - name: default
     image: replaced-by-samson
     args: ["ruby", "-e", "puts 'MIGRATE'"]
+    securityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
     resources:
       requests:
         cpu: '0.1'

--- a/kubernetes/server.yml
+++ b/kubernetes/server.yml
@@ -1,6 +1,6 @@
 # keep all files in sync ... check test/integration/kubernetes_test.rb
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-server
@@ -23,12 +23,12 @@ spec:
         samson/required_env: >
           RAILS_ENV
     spec:
-      securityContext:
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
       containers:
       - name: default
         image: replaced-by-samson
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         resources:
           requests:
             cpu: '0.1'


### PR DESCRIPTION
SecurityContext works on a container level and PodSecurityContext works on a pod level. 
`readOnlyRootFilesystem` is a feature of `SecurityContext`, not a `PodSecurityContext`.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podsecuritycontext-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#securitycontext-v1-core